### PR TITLE
Improve flexibility of the days_before function

### DIFF
--- a/og/og/calibrator.py
+++ b/og/og/calibrator.py
@@ -122,15 +122,18 @@ def days_before(label_name):
 
     adjusted_df, _ = prep_data()
 
-    # For the below, have to convert the true/false label to int because the
-    # underlying numpy operation on diff will throw a deprecation warning.
+    # Get the actual days to offset by subtracting the var from 0.
     days_offset = 0 - int(os.getenv("DAYS_OFFSET", 0))
-    print(days_offset)
+
+    # Add the label diff field used to determine how many days to set backwards
+    # from the start of the event
     adjusted_df["label_diff"] = (
         adjusted_df[label_name].diff(periods=days_offset).fillna(0)
     )
+
+    # Update the label value based on the results of the label_diff value
+    # Have to do a diff < 0 since the future true (1) - the current row false (0) = -1
     adjusted_df[label_name] = adjusted_df.apply(
-        # Have to do a diff <0 since the future true (1) - the current row false (0) = -1
         lambda x: 1 if x[label_name] == 0 and x["label_diff"] < 0 else x[label_name],
         axis=1,
     ).astype(int)

--- a/og/og/calibrator.py
+++ b/og/og/calibrator.py
@@ -124,7 +124,11 @@ def days_before(label_name):
 
     # For the below, have to convert the true/false label to int because the
     # underlying numpy operation on diff will throw a deprecation warning.
-    adjusted_df["label_diff"] = adjusted_df[label_name].diff(periods=-5).fillna(0)
+    days_offset = -int(os.getenv("DAYS_OFFSET", 0))
+    print(days_offset)
+    adjusted_df["label_diff"] = (
+        adjusted_df[label_name].diff(periods=days_offset).fillna(0)
+    )
     adjusted_df[label_name] = adjusted_df.apply(
         # Have to do a diff <0 since the future true (1) - the current row false (0) = -1
         lambda x: 1 if x[label_name] == 0 and x["label_diff"] < 0 else x[label_name],

--- a/og/og/calibrator.py
+++ b/og/og/calibrator.py
@@ -124,7 +124,7 @@ def days_before(label_name):
 
     # For the below, have to convert the true/false label to int because the
     # underlying numpy operation on diff will throw a deprecation warning.
-    days_offset = -int(os.getenv("DAYS_OFFSET", 0))
+    days_offset = 0 - int(os.getenv("DAYS_OFFSET", 0))
     print(days_offset)
     adjusted_df["label_diff"] = (
         adjusted_df[label_name].diff(periods=days_offset).fillna(0)


### PR DESCRIPTION
### Why
* The days_before function should not be hardcoded to offset 5 days before an event.

### How
* Change the logic so it uses an environment var set by the user
* Clean-up the comments